### PR TITLE
fix(#9): auto-assign needs two files

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,9 @@
+# https://github.com/marketplace/actions/auto-assign-action
+addReviewers: true
+
+addAssignees: author
+
+reviewers:
+  - JayeHa
+
+numberOfReviewers: 0

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,12 @@
+name: "Auto Assign"
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: ".github/auto_assign.yml"

--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,9 +1,0 @@
-# Set to true to add reviewers to pull requests
-addReviewers: false
-
-# Set to true to add assignees to pull requests
-addAssignees: author
-
-# A number of reviewers added to the pull request
-# Set 0 to add all the reviewers (default: 0)
-numberOfReviewers: 1


### PR DESCRIPTION
# Description

To properly apply the auto-assign action, two files were needed, and they have been applied.

related #9 

## Type of change

- [X] fix (Fix a bug)
